### PR TITLE
Lazy Loading THOR and Graceful Size Handling

### DIFF
--- a/lambda_functions/analyzer/analyzer_aws_lib.py
+++ b/lambda_functions/analyzer/analyzer_aws_lib.py
@@ -23,6 +23,19 @@ SNS = boto3.resource('sns')
 class FileDownloadError(Exception):
     """File can't be downloaded from S3 with a 4XX error code - do not retry."""
 
+def get_file_size_from_s3(bucket_name: str, object_key: str) -> int:
+    """Get the file size of an object in S3.
+
+    Args:
+        bucket_name: S3 bucket name.
+        object_key: S3 object key.
+
+    Returns:
+        The file size in bytes.
+    """
+    s3_object = S3.Object(bucket_name, object_key)
+    s3_object.load()  # Important to call load() to get the metadata
+    return s3_object.content_length
 
 def download_from_s3(
         bucket_name: str, object_key: str, download_path: str) -> Tuple[str, Dict[str, str]]:
@@ -275,4 +288,5 @@ class DynamoMatchTable:
             needs_alert = True
 
         return needs_alert
+
 

--- a/lambda_functions/analyzer/main.py
+++ b/lambda_functions/analyzer/main.py
@@ -16,9 +16,6 @@ from lambda_functions.analyzer.common import LOGGER
 # Build the YaraAnalyzer from the compiled rules file at import time (i.e. once per container).
 # This saves 50-100+ ms per Lambda invocation, depending on the size of the rules file.
 ANALYZER = yara_analyzer.YaraAnalyzer()
-# Due to a bug in yara-python, num_rules only be computed once. Thereafter, it will return 0.
-# So we have to compute this here since multiple invocations may share the same analyzer.
-NUM_YARA_RULES = ANALYZER.num_rules
 
 
 def _objects_to_analyze(event: Dict[str, Any]) -> Generator[Tuple[str, str], None, None]:
@@ -132,7 +129,7 @@ def analyze_lambda_handler(event: Dict[str, Any], lambda_context: Any) -> Dict[s
     # Publish metrics.
     if binaries:
         try:
-            analyzer_aws_lib.put_metric_data(NUM_YARA_RULES, binaries)
+            analyzer_aws_lib.put_metric_data(ANALYZER.num_rules, binaries)
         except ClientError:
             LOGGER.exception('Error saving metric data')
 

--- a/lambda_functions/analyzer/yara_analyzer.py
+++ b/lambda_functions/analyzer/yara_analyzer.py
@@ -72,13 +72,6 @@ class YaraAnalyzer:
         Returns:
             List of YaraMatch tuples.
         """
-        # UPX-unpack the file if possible
-        try:
-            # Ignore all UPX output
-            subprocess.check_output(['./upx', '-q', '-d', target_file], stderr=subprocess.STDOUT)
-            LOGGER.info('Unpacked UPX-compressed file %s', target_file)
-        except subprocess.CalledProcessError:
-            pass  # Not a packed file
 
         if self.proc is None:
             self._start_thor_server()


### PR DESCRIPTION
## Main Changes

**Problem:** Init timeout when initializing the lambda.

**Cause:**  Since the initial implementation, the Valhalla ruleset has increased by 7000 rules, which has now tipped the initialization of THOR to over 10 seconds causing the lambda init phase to timeout.

**Solution:** Startup of the process has been moved out of the init phase for a lazy load of THOR.

## Additional Changes: 

1. Added a size check for the S3 bucket to only download data for files under a configurable size (<200 MB default) 
**Solves Problem:** Files would always be downloaded regardless of their size, even if they were skipped by BA or THOR causing the lambda to crash because it would run out of storage. Ephemeral storage for the Lambda is 512 MBs and it seems as though the 10 minute timeout occurs before being able to process anything larger than 200 MBs.

2. Added flags to remove storing logs and creating the thordb as we capture the data via sns/sqs not from the logs or db.

3. Tweaked REGEX for clarity