### PR TITLE
Lazy Loading THOR and Graceful Size Handling

### DIFF
--- a/lambda_functions/analyzer/analyzer_aws_lib.py
+++ b/lambda_functions/analyzer/analyzer_aws_lib.py
@@ -33,6 +33,9 @@ def get_file_size_from_s3(bucket_name: str, object_key: str) -> int:
     Returns:
         The file size in bytes.
     """
+    if not object_key:
+        raise ValueError("Object key is empty or invalid")
+
     s3_object = S3.Object(bucket_name, object_key)
     s3_object.load()  # Important to call load() to get the metadata
     return s3_object.content_length
@@ -52,6 +55,8 @@ def download_from_s3(
     Raises:
         FileDownloadError: If the file couldn't be downloaded because
     """
+    if not object_key:
+        raise ValueError("Object key is empty or invalid")
     try:
         s3_object = S3.Object(bucket_name, object_key)
         s3_object.download_file(download_path)
@@ -288,5 +293,4 @@ class DynamoMatchTable:
             needs_alert = True
 
         return needs_alert
-
 

--- a/lambda_functions/analyzer/analyzer_aws_lib.py
+++ b/lambda_functions/analyzer/analyzer_aws_lib.py
@@ -34,8 +34,8 @@ def get_file_size_from_s3(bucket_name: str, object_key: str) -> int:
         The file size in bytes.
     """
     if not object_key:
-        raise ValueError("Object key is empty or invalid")
-
+        return
+    
     s3_object = S3.Object(bucket_name, object_key)
     s3_object.load()  # Important to call load() to get the metadata
     return s3_object.content_length
@@ -56,7 +56,7 @@ def download_from_s3(
         FileDownloadError: If the file couldn't be downloaded because
     """
     if not object_key:
-        raise ValueError("Object key is empty or invalid")
+        return
     try:
         s3_object = S3.Object(bucket_name, object_key)
         s3_object.download_file(download_path)
@@ -293,4 +293,6 @@ class DynamoMatchTable:
             needs_alert = True
 
         return needs_alert
+
+
 

--- a/lambda_functions/analyzer/analyzer_aws_lib.py
+++ b/lambda_functions/analyzer/analyzer_aws_lib.py
@@ -23,6 +23,19 @@ SNS = boto3.resource('sns')
 class FileDownloadError(Exception):
     """File can't be downloaded from S3 with a 4XX error code - do not retry."""
 
+def get_file_size_from_s3(bucket_name: str, object_key: str) -> int:
+    """Get the file size of an object in S3.
+
+    Args:
+        bucket_name: S3 bucket name.
+        object_key: S3 object key.
+
+    Returns:
+        The file size in bytes.
+    """
+    s3_object = S3.Object(bucket_name, object_key)
+    s3_object.load()  # Important to call load() to get the metadata
+    return s3_object.content_length
 
 def download_from_s3(
         bucket_name: str, object_key: str, download_path: str) -> Tuple[str, Dict[str, str]]:
@@ -275,4 +288,5 @@ class DynamoMatchTable:
             needs_alert = True
 
         return needs_alert
+
 

--- a/lambda_functions/analyzer/binary_info.py
+++ b/lambda_functions/analyzer/binary_info.py
@@ -52,7 +52,8 @@ class BinaryInfo:
         if file_size > self.MAX_FILE_SIZE_BYTES:
             LOGGER.warning(f'File {self.object_key} is too large ({file_size} bytes). Skipping download.')
             self.is_skipped = True
-            
+            return
+
         LOGGER.debug('Downloading %s to %s', self.object_key, self.download_path)
         start_time = time.time()
         self.s3_last_modified, self.s3_metadata = analyzer_aws_lib.download_from_s3(
@@ -164,5 +165,6 @@ class BinaryInfo:
             'MatchedRules': matched_rules,
             'NumMatchedRules': len(self.yara_matches)
         }
+
 
 

--- a/lambda_functions/analyzer/binary_info.py
+++ b/lambda_functions/analyzer/binary_info.py
@@ -65,20 +65,18 @@ class BinaryInfo:
         self._download_from_s3()
 
         # Only proceed with analysis if the file was not skipped
-        if os.path.exists(self.download_path):
-            if self.is_skipped:
-                LOGGER.info(f"Skipped analysis for {self.object_key} as the file was not downloaded.")
-            else:
-                self.computed_sha, self.computed_md5 = file_hash.compute_hashes(self.download_path)
 
-                LOGGER.debug('Running YARA analysis')
-                self.yara_matches = self.yara_analyzer.analyze(
-                    self.download_path, original_target_path=self.filepath
-                )
-
-            return self
+        if self.is_skipped:
+            LOGGER.info(f"Skipped analysis for {self.object_key} as the file was not downloaded.")
         else:
-            LOGGER.info(f"File was not downloaded as the key does not exist")
+            self.computed_sha, self.computed_md5 = file_hash.compute_hashes(self.download_path)
+
+            LOGGER.debug('Running YARA analysis')
+            self.yara_matches = self.yara_analyzer.analyze(
+                self.download_path, original_target_path=self.filepath
+            )
+
+        return self
 
     def __exit__(self, exception_type: Any, exception_value: Any, traceback: Any) -> None:
         """Delete all /tmp files (including the downloaded binary)."""

--- a/lambda_functions/analyzer/main.py
+++ b/lambda_functions/analyzer/main.py
@@ -108,8 +108,6 @@ def analyze_lambda_handler(event: Dict[str, Any], lambda_context: Any) -> Dict[s
         LOGGER.info('Analyzing "%s:%s"', bucket_name, object_key)
 
         try:
-            if not object_key:
-                continue
             if analyzer_aws_lib.get_file_size_from_s3(bucket_name, object_key) > binary_info.BinaryInfo.MAX_FILE_SIZE_BYTES:
                 LOGGER.info('File %s is too large - no results created', object_key)
                 continue

--- a/lambda_functions/analyzer/main.py
+++ b/lambda_functions/analyzer/main.py
@@ -108,6 +108,8 @@ def analyze_lambda_handler(event: Dict[str, Any], lambda_context: Any) -> Dict[s
         LOGGER.info('Analyzing "%s:%s"', bucket_name, object_key)
 
         try:
+            if analyzer_aws_lib.get_file_size_from_s3(bucket_name, object_key) > binary_info.BinaryInfo.MAX_FILE_SIZE_BYTES:
+                continue
             with binary_info.BinaryInfo(bucket_name, object_key, ANALYZER) as binary:
                 result[binary.s3_identifier] = binary.summary()
                 binaries.append(binary)
@@ -134,3 +136,4 @@ def analyze_lambda_handler(event: Dict[str, Any], lambda_context: Any) -> Dict[s
             LOGGER.exception('Error saving metric data')
 
     return result
+

--- a/lambda_functions/analyzer/main.py
+++ b/lambda_functions/analyzer/main.py
@@ -108,7 +108,10 @@ def analyze_lambda_handler(event: Dict[str, Any], lambda_context: Any) -> Dict[s
         LOGGER.info('Analyzing "%s:%s"', bucket_name, object_key)
 
         try:
+            if not object_key:
+                continue
             if analyzer_aws_lib.get_file_size_from_s3(bucket_name, object_key) > binary_info.BinaryInfo.MAX_FILE_SIZE_BYTES:
+                LOGGER.info('File %s is too large - no results created', object_key)
                 continue
             with binary_info.BinaryInfo(bucket_name, object_key, ANALYZER) as binary:
                 result[binary.s3_identifier] = binary.summary()
@@ -136,4 +139,5 @@ def analyze_lambda_handler(event: Dict[str, Any], lambda_context: Any) -> Dict[s
             LOGGER.exception('Error saving metric data')
 
     return result
+
 

--- a/lambda_functions/analyzer/main.py
+++ b/lambda_functions/analyzer/main.py
@@ -16,9 +16,6 @@ from lambda_functions.analyzer.common import LOGGER
 # Build the YaraAnalyzer from the compiled rules file at import time (i.e. once per container).
 # This saves 50-100+ ms per Lambda invocation, depending on the size of the rules file.
 ANALYZER = yara_analyzer.YaraAnalyzer()
-# Due to a bug in yara-python, num_rules only be computed once. Thereafter, it will return 0.
-# So we have to compute this here since multiple invocations may share the same analyzer.
-NUM_YARA_RULES = ANALYZER.num_rules
 
 
 def _objects_to_analyze(event: Dict[str, Any]) -> Generator[Tuple[str, str], None, None]:
@@ -132,7 +129,7 @@ def analyze_lambda_handler(event: Dict[str, Any], lambda_context: Any) -> Dict[s
     # Publish metrics.
     if binaries:
         try:
-            analyzer_aws_lib.put_metric_data(NUM_YARA_RULES, binaries)
+            analyzer_aws_lib.put_metric_data(ANALYZER.num_rules, binaries)
         except ClientError:
             LOGGER.exception('Error saving metric data')
 

--- a/lambda_functions/analyzer/yara_analyzer.py
+++ b/lambda_functions/analyzer/yara_analyzer.py
@@ -33,8 +33,8 @@ class YaraAnalyzer:
         """Starts the THOR server."""
         LOGGER.info('Starting THOR server')
         self.proc = subprocess.Popen(
-            ['./thor-linux-64', '--thunderstorm', '--pure-yara', 
-             '--nothordb', '--nolog', '--nocsv'], 
+            ['./thor-linux-64', '--thunderstorm', '--pure-yara',  
+             '--nothordb',  '--nolog', '--nocsv'], 
             stdout=subprocess.PIPE, universal_newlines=True
         )
         startup_successful = False
@@ -46,7 +46,6 @@ class YaraAnalyzer:
             rulecountmatch = RULE_COUNT_REGEX.search(line)
             if rulecountmatch is not None:
                 self._rule_count = int(rulecountmatch.group(1))
-                LOGGER.info('YARA rule count: %d', self._rule_count)
             LOGGER.info(line)
         if not startup_successful:
             LOGGER.info(self.proc.stdout.read())

--- a/lambda_functions/analyzer/yara_analyzer.py
+++ b/lambda_functions/analyzer/yara_analyzer.py
@@ -72,13 +72,6 @@ class YaraAnalyzer:
         Returns:
             List of YaraMatch tuples.
         """
-        # UPX-unpack the file if possible
-        try:
-            # Ignore all UPX output
-            subprocess.check_output(['./upx', '-q', '-d', target_file], stderr=subprocess.STDOUT)
-            LOGGER.info('Unpacked UPX-compressed file %s', target_file)
-        except subprocess.CalledProcessError:
-            pass  # Not a packed file
 
         if self.proc is None:
             self._start_thor_server()


### PR DESCRIPTION
## Main Changes

**Problem:** Init timeout when initializing the lambda.

**Cause:** Since the initial implementation, the Valhalla ruleset has increased by 7000 rules, which has now tipped the initialization of THOR to over 10 seconds causing the lambda init phase to timeout.

**Solution:** Startup of the process has been moved out of the init phase for a lazy load of THOR.

### Additional Changes:

1. Added a size check for the S3 bucket to only download data for files under a configurable size (<200 MB default)
**Solves Problem:** Files would always be downloaded regardless of their size, even if they were skipped by BA or THOR causing the lambda to crash because it would run out of storage. Ephemeral storage for the Lambda is 512 MBs and it seems as though the 10 minute timeout occurs before being able to process anything larger than 200 MBs.

2. After lazy loading THOR the metric for Yara Rules loaded was missing from cloudwatch, this was adjusted

3. Added flags to remove storing logs and creating the thordb as we capture the data via sns/sqs not from the logs or db.

4. Changed from shred to remove as shred started throwing errors again and we just want to clean up the dir

5. Tweaked REGEX for clarity